### PR TITLE
Fix the inconsistency during preprocessing

### DIFF
--- a/Preprocessing/nodes_preparation.py
+++ b/Preprocessing/nodes_preparation.py
@@ -60,21 +60,21 @@ def modify_demand_dict(my_demand_matrix):
 
 if __name__ == '__main__':
     location = "Toy_Example"
-    graph_file = "../Graph/" + location + ".graphml"
-    node_file = "../Graph/node_list_" + location + ".txt"
+    graph_file = "../Graph/" + location + "/" + location + ".graphml"
+    node_file = "../Graph/" + location + "/node_list_" + location + ".txt"
     graph, node_list = ef.prepare_graph(graph_file, node_file)
 
     # open Pickle files with necessary data (in grid structure)
-    with (open("../Graph/Pickle/demand_" + location + ".pkl", "rb")) as f:
+    with (open("../Graph/" + location + "/demand_" + location + ".pkl", "rb")) as f:
         objects = pickle.load(f)
 
-    with (open("../Graph/Pickle/grid_density_" + location + ".pkl", "rb")) as f:
+    with (open("../Graph/" + location + "/grid_density_" + location + ".pkl", "rb")) as f:
         grid_density = pickle.load(f)
 
-    with (open("../Graph/Pickle/privCS_" + location + ".pkl", "rb")) as f:
+    with (open("../Graph/" + location + "/privCS_" + location + ".pkl", "rb")) as f:
         priv_matrix = pickle.load(f)
 
-    with (open("../Graph/Pickle/estateprice_" + location + ".pkl", "rb")) as f:
+    with (open("../Graph/" + location + "/estateprice_" + location + ".pkl", "rb")) as f:
         estate_matrix = pickle.load(f)
 
     """
@@ -131,6 +131,6 @@ if __name__ == '__main__':
             existing_plan.append([s_pos, s_x, {}])
 
     # Save node files
-    with open("../Graph/nodes_extended_" + location + ".txt", 'w') as file:
+    with open("../Graph/" + location + "/nodes_extended_" + location + ".txt", 'w') as file:
         file.write(str(node_list))
-    pickle.dump(existing_plan, open("../Graph/Pickle/existingplan_" + location + ".pkl", "wb"))
+    pickle.dump(existing_plan, open("../Graph/" + location + "/existingplan_" + location + ".pkl", "wb"))


### PR DESCRIPTION
There are a few inconsistencies between load_graph and nodes_preparation.

In nodes_preparation originally, it reads the files right from the `Graph` or `Graph/Pickle` directory.
In the meanwhile, load_graph stores files under `Graph/<location>`. In this case, it's `Graph/Toy_Example`.
Since in the given example, the files are also stored in `Graph/<location>`, I believed that these files are intended to be classified by their location, which means following the way load_graph does.

Moreover, other programs in the following steps like reinforcement.py, env_plus.py, model_eval.py, etc. are all using an addition directory under `Graph` named after the location name e.g. "Graph/" + location + "/" + location + ".graphml" instead of just "Graph/" + location + ".graphml".

Thus, some changes in nodes_preparation are conducted to read files based on the corresponding location name.
Though it still can't be executed with the given inadequate example files, it provides better clarity and consistency now.