### PR TITLE
Check if the logging directory exists before training

### DIFF
--- a/reinforcement.py
+++ b/reinforcement.py
@@ -33,11 +33,6 @@ class SaveOnBestTrainingRewardCallback(BaseCallback):
         self.save_path = os.path.join(self.log_dir, self.modelname)
         self.best_mean_reward = -np.inf
 
-    def _init_callback(self) -> None:
-        # Create folder if needed
-        if self.save_path is not None:
-            os.makedirs(self.save_path, exist_ok=True)
-
     def _on_step(self) -> bool:
         if self.n_calls % self.check_freq == 0:
 
@@ -58,8 +53,6 @@ class SaveOnBestTrainingRewardCallback(BaseCallback):
                         print("New best mean reward: {:.2f}".format(self.best_mean_reward))
                         # we want to make sure that the best models are not overwritten
                         new_name = self.modelname + str(self.num_timesteps)
-                        if self.save_path is not None:
-                            os.makedirs(self.save_path, exist_ok=True)
                         self.save_path = os.path.join(self.log_dir, new_name)
                         print("Saving new best model to {}".format(self.save_path))
                     self.model.save(self.save_path)

--- a/reinforcement.py
+++ b/reinforcement.py
@@ -84,6 +84,8 @@ if __name__ == '__main__':
     log_dir = "tmp_Toy_Example/"
     modelname = "best_model_" + location + "_"
 
+    os.makedirs(log_dir, exist_ok=True)
+
     """
     Define and train the agent 
     """


### PR DESCRIPTION
In the original reinforcement training program, the monitor is set to the logging directory without checking whether it exists or not.

Still, the directory is checked and created in the callback, but it only happens after the monitor is set.

Therefore, a typical "no such file or directory" error occurs when users first try to run it after cloning the repo.
The program now will try to create the directory, errors are expected to occur only when the creation fails.