### PR TITLE
Update url in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We use [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3) as Reinf
 
 To install the requirements
 ```bash
-git clone git@github.com:frantz03/PCRL.git
+git clone git@github.com:ashusao/PCRL.git
 pip install -r final_requirements.txt
 ```
 


### PR DESCRIPTION
The origin url provided in README is nearly an empty repo. This url is now updated as the current repo.