### PR TITLE
Check if the image directory exists before visualizing

### DIFF
--- a/Visualisierung/visualise.py
+++ b/Visualisierung/visualise.py
@@ -3,7 +3,7 @@ import osmnx as ox
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 import numpy as np
-import sys
+import sys, os
 sys.path.append("..")  # Adds higher directory to python modules path.
 import evaluation_framework as ef
 
@@ -62,5 +62,8 @@ if __name__ == '__main__':
 
     with (open("../Results/" + ort + "/plan_RL.pkl", "rb")) as f:
         plan = pickle.load(f)
+
+    os.makedirs("../Images/Result_Plots/" + ort, exist_ok=True)
+    
     visualise_stations(G, plan, "../Images/Result_Plots/" + ort + "/RL_" + ort + ".png")
 


### PR DESCRIPTION
In the original visualization program, the result is visualized as an image in the image directory without checking whether it exists or not.
Therefore, a typical "no such file or directory" error occurs when users first try to run it after cloning the repo.
The program now will try to create the directory, errors are expected to occur only when the creation fails.

#2 